### PR TITLE
fix temperature_hot_water_target

### DIFF
--- a/src/lux-meta.ts
+++ b/src/lux-meta.ts
@@ -180,7 +180,7 @@ export const luxMeta: Record<string, Record<string, MetaInfo | undefined>> = {
             role: 'value.temperature',
             type: 'number',
             unit: '°C',
-            writeName: 'warmwater_target_temperature',
+            writeName: 'temperature_hot_water_target',
             min: 30,
             max: 65,
         },


### PR DESCRIPTION
Hiermit lässt sich "Wunschtemperatur" statt "Deckung WP" für Warmwasser einstellen